### PR TITLE
Add synthetic exit node to function CFG

### DIFF
--- a/src/cfg/block.rs
+++ b/src/cfg/block.rs
@@ -14,6 +14,8 @@ pub struct Block {
     pub start_pc: u32,
     /// End PC of this block
     pub end_pc: u32,
+    /// Whether this is a synthetic EXIT block
+    pub is_exit: bool,
 }
 
 impl Block {
@@ -28,6 +30,17 @@ impl Block {
             instructions,
             start_pc,
             end_pc,
+            is_exit: false,
+        }
+    }
+
+    /// Create a new synthetic EXIT block
+    pub fn new_exit() -> Self {
+        Self {
+            instructions: Vec::new(),
+            start_pc: u32::MAX, // Use MAX to indicate synthetic
+            end_pc: u32::MAX,
+            is_exit: true,
         }
     }
 
@@ -69,6 +82,20 @@ impl Block {
     pub fn ends_with_jump(&self) -> bool {
         if let Some(last) = self.last_instruction() {
             matches!(last.instruction.category(), "Jump")
+        } else {
+            false
+        }
+    }
+
+    /// Check if this is a synthetic EXIT block
+    pub fn is_exit(&self) -> bool {
+        self.is_exit
+    }
+
+    /// Check if this block is terminating (ends with Return or Throw)
+    pub fn is_terminating(&self) -> bool {
+        if let Some(last) = self.last_instruction() {
+            matches!(last.instruction.category(), "Return" | "Exception")
         } else {
             false
         }

--- a/src/cfg/builder.rs
+++ b/src/cfg/builder.rs
@@ -205,7 +205,10 @@ impl CfgBuilder {
 
             // Check if block ends with a terminating instruction (Return/Throw)
             if let Some(last_instruction) = instructions.last() {
-                if matches!(last_instruction.instruction.category(), "Return" | "Exception") {
+                if matches!(
+                    last_instruction.instruction.category(),
+                    "Return" | "Exception"
+                ) {
                     // Connect terminating blocks to EXIT node
                     if let Some(exit_node) = self.exit_node {
                         graph.add_edge(from_node, exit_node, EdgeKind::Uncond);

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -127,7 +127,8 @@ impl Cfg {
                 let block = &self.graph[node];
                 if block.is_terminating() {
                     // Check if this terminating block has a direct edge to EXIT
-                    let has_exit_edge = self.graph
+                    let has_exit_edge = self
+                        .graph
                         .neighbors_directed(node, petgraph::Direction::Outgoing)
                         .any(|neighbor| neighbor == exit_node);
                     if !has_exit_edge {
@@ -138,7 +139,10 @@ impl Cfg {
             true
         } else {
             // If no EXIT node, check if there are any terminating blocks
-            !self.graph.node_indices().any(|node| self.graph[node].is_terminating())
+            !self
+                .graph
+                .node_indices()
+                .any(|node| self.graph[node].is_terminating())
         }
     }
 

--- a/src/cfg/mod.rs
+++ b/src/cfg/mod.rs
@@ -106,6 +106,46 @@ impl Cfg {
     pub fn to_dot(&self) -> String {
         self.builder.to_dot(&self.graph)
     }
+
+    /// Get the EXIT node for the current function
+    pub fn exit_node(&self) -> Option<NodeIndex> {
+        self.builder.exit_node()
+    }
+
+    /// Find all EXIT nodes in the graph
+    pub fn find_exit_nodes(&self) -> Vec<NodeIndex> {
+        self.graph
+            .node_indices()
+            .filter(|&node| self.graph[node].is_exit())
+            .collect()
+    }
+
+    /// Check if all terminating blocks have a path to EXIT
+    pub fn all_terminators_reach_exit(&self) -> bool {
+        if let Some(exit_node) = self.exit_node() {
+            for node in self.graph.node_indices() {
+                let block = &self.graph[node];
+                if block.is_terminating() {
+                    // Check if this terminating block has a direct edge to EXIT
+                    let has_exit_edge = self.graph
+                        .neighbors_directed(node, petgraph::Direction::Outgoing)
+                        .any(|neighbor| neighbor == exit_node);
+                    if !has_exit_edge {
+                        return false;
+                    }
+                }
+            }
+            true
+        } else {
+            // If no EXIT node, check if there are any terminating blocks
+            !self.graph.node_indices().any(|node| self.graph[node].is_terminating())
+        }
+    }
+
+    /// Check if the CFG remains acyclic
+    pub fn is_acyclic(&self) -> bool {
+        !petgraph::algo::is_cyclic_directed(&self.graph)
+    }
 }
 
 impl Default for Cfg {

--- a/tests/cfg.rs
+++ b/tests/cfg.rs
@@ -3,6 +3,7 @@ use hermes_dec_rs::cfg::{Block, Cfg, EdgeKind};
 use hermes_dec_rs::generated::unified_instructions::UnifiedInstruction;
 use hermes_dec_rs::hbc::function_table::HbcFunctionInstruction;
 use petgraph::graph::DiGraph;
+use petgraph::visit::EdgeRef;
 
 #[test]
 fn test_cfg_creation() {
@@ -53,12 +54,16 @@ fn test_cfg_building_with_single_instruction() {
     let instructions = vec![instruction];
     cfg.build_from_instructions(&instructions, 0);
 
-    // Should have one block
-    assert_eq!(cfg.graph().node_count(), 1);
+    // Should have two blocks: one regular block + one EXIT block
+    assert_eq!(cfg.graph().node_count(), 2);
     assert_eq!(cfg.graph().edge_count(), 0);
 
-    // Check the block contents
-    let block = &cfg.graph()[cfg.graph().node_indices().next().unwrap()];
+    // Find the non-EXIT block and check its contents
+    let regular_block = cfg.graph()
+        .node_indices()
+        .find(|&node| !cfg.graph()[node].is_exit())
+        .unwrap();
+    let block = &cfg.graph()[regular_block];
     assert_eq!(block.start_pc, 0);
     assert_eq!(block.instruction_count(), 1);
 }
@@ -94,6 +99,266 @@ fn test_pc_lookup_three_blocks() {
 }
 
 #[test]
+fn test_exit_node_creation() {
+    let mut cfg = Cfg::new();
+
+    // Create a simple Return instruction
+    let instruction = HbcFunctionInstruction {
+        offset: 0,
+        function_index: 0,
+        instruction_index: 0,
+        instruction: UnifiedInstruction::Ret { operand_0: 1 },
+    };
+
+    let instructions = vec![instruction];
+    cfg.build_from_instructions(&instructions, 0);
+
+    // Should have two blocks: one regular block + one EXIT block
+    assert_eq!(cfg.graph().node_count(), 2);
+    assert_eq!(cfg.graph().edge_count(), 1); // Return -> EXIT edge
+
+    // Should have exactly one EXIT node
+    let exit_nodes = cfg.find_exit_nodes();
+    assert_eq!(exit_nodes.len(), 1);
+
+    // EXIT node should be accessible via exit_node() method
+    let exit_node = cfg.exit_node();
+    assert!(exit_node.is_some());
+    assert_eq!(exit_node.unwrap(), exit_nodes[0]);
+
+    // EXIT node should have no outgoing edges
+    let exit_node = exit_nodes[0];
+    let outgoing_edges = cfg.graph()
+        .neighbors_directed(exit_node, petgraph::Direction::Outgoing)
+        .count();
+    assert_eq!(outgoing_edges, 0);
+}
+
+#[test]
+fn test_return_instruction_connects_to_exit() {
+    let mut cfg = Cfg::new();
+
+    // Create a Return instruction
+    let ret_instruction = HbcFunctionInstruction {
+        offset: 0,
+        function_index: 0,
+        instruction_index: 0,
+        instruction: UnifiedInstruction::Ret { operand_0: 1 },
+    };
+
+    let instructions = vec![ret_instruction];
+    cfg.build_from_instructions(&instructions, 0);
+
+    // Find the return block and EXIT block
+    let exit_node = cfg.exit_node().unwrap();
+    let return_block = cfg.graph()
+        .node_indices()
+        .find(|&node| !cfg.graph()[node].is_exit())
+        .unwrap();
+
+    // Return block should have edge to EXIT
+    let has_exit_edge = cfg.graph()
+        .neighbors_directed(return_block, petgraph::Direction::Outgoing)
+        .any(|neighbor| neighbor == exit_node);
+    assert!(has_exit_edge);
+
+    // Check that the edge is unconditional
+    let edge = cfg.graph()
+        .edges_directed(return_block, petgraph::Direction::Outgoing)
+        .find(|edge| edge.target() == exit_node)
+        .unwrap();
+    assert_eq!(*edge.weight(), hermes_dec_rs::cfg::EdgeKind::Uncond);
+}
+
+#[test]
+fn test_throw_instruction_connects_to_exit() {
+    let mut cfg = Cfg::new();
+
+    // Create a Throw instruction
+    let throw_instruction = HbcFunctionInstruction {
+        offset: 0,
+        function_index: 0,
+        instruction_index: 0,
+        instruction: UnifiedInstruction::Throw { operand_0: 1 },
+    };
+
+    let instructions = vec![throw_instruction];
+    cfg.build_from_instructions(&instructions, 0);
+
+    // Find the throw block and EXIT block
+    let exit_node = cfg.exit_node().unwrap();
+    let throw_block = cfg.graph()
+        .node_indices()
+        .find(|&node| !cfg.graph()[node].is_exit())
+        .unwrap();
+
+    // Throw block should have edge to EXIT
+    let has_exit_edge = cfg.graph()
+        .neighbors_directed(throw_block, petgraph::Direction::Outgoing)
+        .any(|neighbor| neighbor == exit_node);
+    assert!(has_exit_edge);
+
+    // Check that the edge is unconditional
+    let edge = cfg.graph()
+        .edges_directed(throw_block, petgraph::Direction::Outgoing)
+        .find(|edge| edge.target() == exit_node)
+        .unwrap();
+    assert_eq!(*edge.weight(), hermes_dec_rs::cfg::EdgeKind::Uncond);
+}
+
+#[test]
+fn test_all_terminating_blocks_reach_exit() {
+    let mut cfg = Cfg::new();
+
+    // Create multiple terminating instructions
+    let instructions = vec![
+        HbcFunctionInstruction {
+            offset: 0,
+            function_index: 0,
+            instruction_index: 0,
+            instruction: UnifiedInstruction::LoadConstUInt8 {
+                operand_0: 1,
+                operand_1: 42,
+            },
+        },
+        HbcFunctionInstruction {
+            offset: 2,
+            function_index: 0,
+            instruction_index: 1,
+            instruction: UnifiedInstruction::Ret { operand_0: 1 },
+        },
+        HbcFunctionInstruction {
+            offset: 4,
+            function_index: 0,
+            instruction_index: 2,
+            instruction: UnifiedInstruction::LoadConstUInt8 {
+                operand_0: 2,
+                operand_1: 100,
+            },
+        },
+        HbcFunctionInstruction {
+            offset: 6,
+            function_index: 0,
+            instruction_index: 3,
+            instruction: UnifiedInstruction::Throw { operand_0: 2 },
+        },
+    ];
+
+    cfg.build_from_instructions(&instructions, 0);
+
+    // Should have one EXIT node
+    assert_eq!(cfg.find_exit_nodes().len(), 1);
+
+    // All terminating blocks should reach EXIT
+    assert!(cfg.all_terminators_reach_exit());
+}
+
+#[test]
+fn test_cfg_remains_acyclic_with_exit() {
+    let mut cfg = Cfg::new();
+
+    // Create a CFG with various control structures
+    let instructions = vec![
+        HbcFunctionInstruction {
+            offset: 0,
+            function_index: 0,
+            instruction_index: 0,
+            instruction: UnifiedInstruction::LoadConstUInt8 {
+                operand_0: 1,
+                operand_1: 42,
+            },
+        },
+        HbcFunctionInstruction {
+            offset: 2,
+            function_index: 0,
+            instruction_index: 1,
+            instruction: UnifiedInstruction::JmpTrue {
+                operand_0: 2, // Jump forward to return
+                operand_1: 1,
+            },
+        },
+        HbcFunctionInstruction {
+            offset: 4,
+            function_index: 0,
+            instruction_index: 2,
+            instruction: UnifiedInstruction::Throw { operand_0: 2 },
+        },
+        HbcFunctionInstruction {
+            offset: 6,
+            function_index: 0,
+            instruction_index: 3,
+            instruction: UnifiedInstruction::Ret { operand_0: 1 },
+        },
+    ];
+
+    cfg.build_from_instructions(&instructions, 0);
+
+    // CFG should remain acyclic
+    assert!(cfg.is_acyclic());
+
+    // Should have EXIT node
+    assert!(cfg.exit_node().is_some());
+}
+
+#[test]
+fn test_exit_node_has_no_outgoing_edges() {
+    let mut cfg = Cfg::new();
+
+    // Create any function with terminating instruction
+    let instruction = HbcFunctionInstruction {
+        offset: 0,
+        function_index: 0,
+        instruction_index: 0,
+        instruction: UnifiedInstruction::Ret { operand_0: 1 },
+    };
+
+    let instructions = vec![instruction];
+    cfg.build_from_instructions(&instructions, 0);
+
+    let exit_node = cfg.exit_node().unwrap();
+
+    // EXIT node should have no outgoing edges (true sink)
+    let outgoing_count = cfg.graph()
+        .neighbors_directed(exit_node, petgraph::Direction::Outgoing)
+        .count();
+    assert_eq!(outgoing_count, 0);
+
+    // EXIT node should have incoming edges
+    let incoming_count = cfg.graph()
+        .neighbors_directed(exit_node, petgraph::Direction::Incoming)
+        .count();
+    assert!(incoming_count > 0);
+}
+
+#[test]
+fn test_dominator_analysis_includes_exit() {
+    let mut cfg = Cfg::new();
+
+    // Create a simple function with return
+    let instruction = HbcFunctionInstruction {
+        offset: 0,
+        function_index: 0,
+        instruction_index: 0,
+        instruction: UnifiedInstruction::Ret { operand_0: 1 },
+    };
+
+    let instructions = vec![instruction];
+    cfg.build_from_instructions(&instructions, 0);
+
+    // Dominator analysis should work with EXIT node
+    let dominators = cfg.analyze_dominators();
+    assert!(dominators.is_some());
+
+    // Should be able to compute dominators for all nodes including EXIT
+    let dominators = dominators.unwrap();
+    for node in cfg.graph().node_indices() {
+        // Each node should have dominator information (or be the root)
+        let _idom = dominators.immediate_dominator(node);
+        // This shouldn't panic
+    }
+}
+
+#[test]
 fn test_pc_lookup_overlapping_blocks() {
     let mut builder = CfgBuilder::new(0);
     let mut graph: DiGraph<Block, EdgeKind> = DiGraph::new();
@@ -115,4 +380,57 @@ fn test_pc_lookup_overlapping_blocks() {
     assert_eq!(builder.get_block_at_pc(1), Some(n_b));
     assert_eq!(builder.get_block_at_pc(2), Some(n_b));
     assert!(!builder.is_pc_in_block(3));
+}
+
+#[test]
+fn test_empty_function_has_no_exit() {
+    let mut cfg = Cfg::new();
+    cfg.build_from_instructions(&[], 0);
+
+    // Empty function should have no nodes and no EXIT
+    assert_eq!(cfg.graph().node_count(), 0);
+    assert_eq!(cfg.graph().edge_count(), 0);
+    assert!(cfg.exit_node().is_none());
+    assert_eq!(cfg.find_exit_nodes().len(), 0);
+}
+
+#[test]
+fn test_non_terminating_function_still_has_exit() {
+    let mut cfg = Cfg::new();
+
+    // Create a function with only non-terminating instructions
+    let instructions = vec![
+        HbcFunctionInstruction {
+            offset: 0,
+            function_index: 0,
+            instruction_index: 0,
+            instruction: UnifiedInstruction::LoadConstUInt8 {
+                operand_0: 1,
+                operand_1: 42,
+            },
+        },
+        HbcFunctionInstruction {
+            offset: 2,
+            function_index: 0,
+            instruction_index: 1,
+            instruction: UnifiedInstruction::Add {
+                operand_0: 1,
+                operand_1: 1,
+                operand_2: 1,
+            },
+        },
+    ];
+
+    cfg.build_from_instructions(&instructions, 0);
+
+    // Should still have EXIT node even if no terminators
+    assert!(cfg.exit_node().is_some());
+    assert_eq!(cfg.find_exit_nodes().len(), 1);
+
+    // No edges should connect to EXIT since no terminators
+    let exit_node = cfg.exit_node().unwrap();
+    let incoming_count = cfg.graph()
+        .neighbors_directed(exit_node, petgraph::Direction::Incoming)
+        .count();
+    assert_eq!(incoming_count, 0);
 }

--- a/tests/cfg.rs
+++ b/tests/cfg.rs
@@ -59,7 +59,8 @@ fn test_cfg_building_with_single_instruction() {
     assert_eq!(cfg.graph().edge_count(), 0);
 
     // Find the non-EXIT block and check its contents
-    let regular_block = cfg.graph()
+    let regular_block = cfg
+        .graph()
         .node_indices()
         .find(|&node| !cfg.graph()[node].is_exit())
         .unwrap();
@@ -128,7 +129,8 @@ fn test_exit_node_creation() {
 
     // EXIT node should have no outgoing edges
     let exit_node = exit_nodes[0];
-    let outgoing_edges = cfg.graph()
+    let outgoing_edges = cfg
+        .graph()
         .neighbors_directed(exit_node, petgraph::Direction::Outgoing)
         .count();
     assert_eq!(outgoing_edges, 0);
@@ -151,19 +153,22 @@ fn test_return_instruction_connects_to_exit() {
 
     // Find the return block and EXIT block
     let exit_node = cfg.exit_node().unwrap();
-    let return_block = cfg.graph()
+    let return_block = cfg
+        .graph()
         .node_indices()
         .find(|&node| !cfg.graph()[node].is_exit())
         .unwrap();
 
     // Return block should have edge to EXIT
-    let has_exit_edge = cfg.graph()
+    let has_exit_edge = cfg
+        .graph()
         .neighbors_directed(return_block, petgraph::Direction::Outgoing)
         .any(|neighbor| neighbor == exit_node);
     assert!(has_exit_edge);
 
     // Check that the edge is unconditional
-    let edge = cfg.graph()
+    let edge = cfg
+        .graph()
         .edges_directed(return_block, petgraph::Direction::Outgoing)
         .find(|edge| edge.target() == exit_node)
         .unwrap();
@@ -187,19 +192,22 @@ fn test_throw_instruction_connects_to_exit() {
 
     // Find the throw block and EXIT block
     let exit_node = cfg.exit_node().unwrap();
-    let throw_block = cfg.graph()
+    let throw_block = cfg
+        .graph()
         .node_indices()
         .find(|&node| !cfg.graph()[node].is_exit())
         .unwrap();
 
     // Throw block should have edge to EXIT
-    let has_exit_edge = cfg.graph()
+    let has_exit_edge = cfg
+        .graph()
         .neighbors_directed(throw_block, petgraph::Direction::Outgoing)
         .any(|neighbor| neighbor == exit_node);
     assert!(has_exit_edge);
 
     // Check that the edge is unconditional
-    let edge = cfg.graph()
+    let edge = cfg
+        .graph()
         .edges_directed(throw_block, petgraph::Direction::Outgoing)
         .find(|edge| edge.target() == exit_node)
         .unwrap();
@@ -318,13 +326,15 @@ fn test_exit_node_has_no_outgoing_edges() {
     let exit_node = cfg.exit_node().unwrap();
 
     // EXIT node should have no outgoing edges (true sink)
-    let outgoing_count = cfg.graph()
+    let outgoing_count = cfg
+        .graph()
         .neighbors_directed(exit_node, petgraph::Direction::Outgoing)
         .count();
     assert_eq!(outgoing_count, 0);
 
     // EXIT node should have incoming edges
-    let incoming_count = cfg.graph()
+    let incoming_count = cfg
+        .graph()
         .neighbors_directed(exit_node, petgraph::Direction::Incoming)
         .count();
     assert!(incoming_count > 0);
@@ -429,7 +439,8 @@ fn test_non_terminating_function_still_has_exit() {
 
     // No edges should connect to EXIT since no terminators
     let exit_node = cfg.exit_node().unwrap();
-    let incoming_count = cfg.graph()
+    let incoming_count = cfg
+        .graph()
         .neighbors_directed(exit_node, petgraph::Direction::Incoming)
         .count();
     assert_eq!(incoming_count, 0);


### PR DESCRIPTION
Add synthetic EXIT nodes to the CFG and connect Return/Throw terminators to them.

This change is essential for accurate dominator and post-dominator analysis (CFG-06) by providing a single, well-defined exit point for each function's control flow graph.

---

[Open in Web](https://www.cursor.com/agents%3Fid=bc-d9e8755a-ac09-49eb-b6ae-ae242516df0b) • [Open in Cursor](https://cursor.com/background-agent%3FbcId=bc-d9e8755a-ac09-49eb-b6ae-ae242516df0b)

Addresses #2 